### PR TITLE
fix(quill): workaround double toolbar

### DIFF
--- a/src/Wysiwyg.tsx
+++ b/src/Wysiwyg.tsx
@@ -10,7 +10,7 @@ export default function Wysiwyg({
   onChange: (value: string) => void;
   placeholder?: string;
 }) {
-  let quillObj: ReactQuill | null;
+  const quillObj = React.useRef<ReactQuill | null>(null);
 
   const handleImageUpload = async () => {
     const input = document.createElement('input');
@@ -20,8 +20,8 @@ export default function Wysiwyg({
     input.click();
 
     input.onchange = async () => {
-      if (quillObj) {
-        const range = quillObj.getEditorSelection();
+      if (quillObj.current) {
+        const range = quillObj.current.getEditorSelection();
 
         if (range) {
           const files = input.files;
@@ -42,7 +42,7 @@ export default function Wysiwyg({
             });
 
             if (response.ok) {
-              quillObj
+              quillObj.current
                 .getEditor()
                 .insertEmbed(range.index, 'image', `/api/images/${filename}`);
             }
@@ -55,7 +55,7 @@ export default function Wysiwyg({
   return (
     <ReactQuill
       ref={(el) => {
-        quillObj = el;
+        quillObj.current = el;
       }}
       value={value}
       onChange={onChange}

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.quill > .ql-toolbar:first-child {
+  display: none !important;
+}


### PR DESCRIPTION
I moved quill to a useRef just to be safe.
This is  a known issue with Quill:
https://github.com/zenoamaro/react-quill/issues/784#issuecomment-1130550582
I applied the workaround in index.css.